### PR TITLE
Feature create CLI + basic project toml and cache folder  

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-addition.md
+++ b/.github/ISSUE_TEMPLATE/feature-addition.md
@@ -1,10 +1,8 @@
 ---
 name: Feature Addition
 about: Info outlining new feature
-title: ''
+title: ""
 labels: feature
 assignees: sethclim
-
+projects: ["sethclim/BoxPkg Project"]
 ---
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+temp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,246 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "cli"
 version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "manifest"
 version = "0.1.0"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,8 @@ name = "cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -106,10 +108,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -120,6 +144,12 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 [[package]]
 name = "manifest"
 version = "0.1.0"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
@@ -146,6 +176,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +219,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -246,3 +339,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -49,8 +49,31 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "box_core"
+version = "0.1.0"
+dependencies = [
+ "os_info",
+ "sha2",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -96,6 +119,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "box_core",
  "clap",
  "serde",
  "toml",
@@ -108,10 +132,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "hashbrown"
@@ -142,8 +205,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "manifest"
-version = "0.1.0"
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -156,6 +227,17 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "os_info"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -202,6 +284,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -256,6 +349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +365,21 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
-members = ["cli", "manifest"]
+members = ["cli", "box_core"]
 
 resolver = "3"

--- a/box_core/Cargo.toml
+++ b/box_core/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
-name = "manifest"
+name = "box_core"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+os_info = "3.10.0"
+sha2 = "0.10.8"

--- a/box_core/src/build_tuple.rs
+++ b/box_core/src/build_tuple.rs
@@ -1,0 +1,36 @@
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct BuildTuple {
+    pub package: String,
+    pub package_version: String,
+
+    pub python_version: String,   // e.g. "3.11"
+    pub platform: String,         // e.g. "windows-x86_64", "linux-aarch64"
+    pub abi: String,              // e.g. "cp311", "abi3", "none"
+    pub compiler: Option<String>, // e.g. "msvc", "gcc", "clang"
+
+    pub build_flags: BTreeMap<String, String>, // e.g. "WITH_SSL" => "ON"
+}
+
+impl BuildTuple {
+    pub fn hash_key(&self) -> String {
+        let mut hasher = Sha256::new();
+        let mut data = format!(
+            "{}@{}|{}|{}|{}|{}|",
+            self.package,
+            self.package_version,
+            self.python_version,
+            self.platform,
+            self.abi,
+            self.compiler.clone().unwrap_or_default()
+        );
+        for (k, v) in &self.build_flags {
+            data.push_str(&format!("{}={};", k, v));
+        }
+
+        hasher.update(data);
+        format!("{:x}", hasher.finalize())
+    }
+}

--- a/box_core/src/build_tuple.rs
+++ b/box_core/src/build_tuple.rs
@@ -5,12 +5,10 @@ use std::collections::BTreeMap;
 pub struct BuildTuple {
     pub package: String,
     pub package_version: String,
-
-    pub python_version: String,   // e.g. "3.11"
-    pub platform: String,         // e.g. "windows-x86_64", "linux-aarch64"
-    pub abi: String,              // e.g. "cp311", "abi3", "none"
-    pub compiler: Option<String>, // e.g. "msvc", "gcc", "clang"
-
+    pub python_version: String,                // e.g. "3.11"
+    pub platform: String,                      // e.g. "windows-x86_64", "linux-aarch64"
+    pub abi: String,                           // e.g. "cp311", "abi3", "none"
+    pub compiler: Option<String>,              // e.g. "msvc", "gcc", "clang"
     pub build_flags: BTreeMap<String, String>, // e.g. "WITH_SSL" => "ON"
 }
 

--- a/box_core/src/lib.rs
+++ b/box_core/src/lib.rs
@@ -14,14 +14,9 @@ pub struct SystemEnvironmentInfo {
     pub abi_tag: String,
 }
 
-pub fn test() {
-    println!("Hello, world!");
-
+pub fn get_system_info() -> SystemEnvironmentInfo {
     let py = detect_python_version();
     let abi = detect_abi_tag().unwrap_or("None".to_string());
-
-    println!("python version: {:#?}", py);
-    println!("abi: {:#?}", abi);
 
     let system_env: SystemEnvironmentInfo = SystemEnvironmentInfo {
         platform: detect_platform().to_string(),
@@ -34,13 +29,17 @@ pub fn test() {
         system_env.platform, system_env.python_version, system_env.abi_tag
     );
 
+    return system_env;
+}
+
+pub fn get_build_tuple(name: &str, version: &str, system_env: SystemEnvironmentInfo) -> BuildTuple {
     let mut flags = BTreeMap::new();
     flags.insert("WITH_SSL".to_string(), "ON".to_string());
     flags.insert("ENABLE_THREADS".to_string(), "OFF".to_string());
 
     let tuple = BuildTuple {
-        package: "zlib".to_string(),
-        package_version: "1.2.13".to_string(),
+        package: name.to_string(),
+        package_version: version.to_string(),
         python_version: system_env.python_version,
         platform: system_env.platform,
         abi: system_env.abi_tag,
@@ -48,6 +47,8 @@ pub fn test() {
         build_flags: flags,
     };
 
-    println!("Build tuple: {:#?}", tuple);
-    println!("Cache key: {}", tuple.hash_key());
+    // println!("Build tuple: {:#?}", tuple);
+    // println!("Cache key: {}", tuple.hash_key());
+
+    return tuple;
 }

--- a/box_core/src/lib.rs
+++ b/box_core/src/lib.rs
@@ -1,0 +1,53 @@
+use std::collections::BTreeMap;
+
+mod build_tuple;
+
+use crate::build_tuple::BuildTuple;
+
+mod system_resolver;
+use system_resolver::{detect_abi_tag, detect_platform, detect_python_version};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct SystemEnvironmentInfo {
+    pub platform: String,
+    pub python_version: String,
+    pub abi_tag: String,
+}
+
+pub fn test() {
+    println!("Hello, world!");
+
+    let py = detect_python_version();
+    let abi = detect_abi_tag().unwrap_or("None".to_string());
+
+    println!("python version: {:#?}", py);
+    println!("abi: {:#?}", abi);
+
+    let system_env: SystemEnvironmentInfo = SystemEnvironmentInfo {
+        platform: detect_platform().to_string(),
+        python_version: py.unwrap_or("".to_string()),
+        abi_tag: abi,
+    };
+
+    println!(
+        "platform {} python_version {} abi_tag {}",
+        system_env.platform, system_env.python_version, system_env.abi_tag
+    );
+
+    let mut flags = BTreeMap::new();
+    flags.insert("WITH_SSL".to_string(), "ON".to_string());
+    flags.insert("ENABLE_THREADS".to_string(), "OFF".to_string());
+
+    let tuple = BuildTuple {
+        package: "zlib".to_string(),
+        package_version: "1.2.13".to_string(),
+        python_version: system_env.python_version,
+        platform: system_env.platform,
+        abi: system_env.abi_tag,
+        compiler: Some("gcc".to_string()),
+        build_flags: flags,
+    };
+
+    println!("Build tuple: {:#?}", tuple);
+    println!("Cache key: {}", tuple.hash_key());
+}

--- a/box_core/src/system_resolver.rs
+++ b/box_core/src/system_resolver.rs
@@ -1,0 +1,60 @@
+use std::process::Command;
+
+pub fn detect_platform() -> String {
+    let info = os_info::get();
+    let arch = info.architecture().unwrap_or("unknown");
+    println!("Type: {}", info.os_type());
+    // println!("Architecture: {}", info.architecture());
+
+    let key = format!("{}-{}", info.os_type(), arch);
+    return key;
+}
+
+pub fn detect_python_version() -> Option<String> {
+    let output = Command::new("python3")
+        .arg("--version")
+        .output()
+        .or_else(|_| Command::new("python").arg("--version").output())
+        .ok()?;
+
+    if output.status.success() {
+        let version_str = String::from_utf8_lossy(&output.stdout);
+        let trimmed = version_str.trim().replace("Python ", "");
+        Some(trimmed)
+    } else {
+        None
+    }
+}
+
+pub fn detect_abi_tag() -> Option<String> {
+    let try_gcc = Command::new("gcc").arg("-dumpfullversion").output().ok();
+    if let Some(output) = try_gcc {
+        if output.status.success() {
+            let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            return Some(format!("gcc{}", ver.replace('.', "_")));
+        }
+    }
+
+    let try_clang = Command::new("clang").arg("--version").output().ok();
+    if let Some(output) = try_clang {
+        if output.status.success() {
+            let version_line = String::from_utf8_lossy(&output.stdout);
+            if let Some(ver) = version_line.split_whitespace().nth(2) {
+                return Some(format!("clang{}", ver.replace('.', "_")));
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let try_cl = Command::new("cl").arg("/Bv").output().ok();
+        if let Some(output) = try_cl {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.contains("Microsoft (R) C/C++") {
+                return Some("msvc14".to_string()); // crude version, improve as needed
+            }
+        }
+    }
+
+    None
+}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.37", features = ["derive"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.20"
+box_core = { path = "../box_core" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
+toml = "0.8.20"

--- a/cli/mypkg.toml
+++ b/cli/mypkg.toml
@@ -1,5 +1,0 @@
-[project]
-name = "myproject"
-version = "0.1.0"
-
-[dependencies]

--- a/cli/mypkg.toml
+++ b/cli/mypkg.toml
@@ -1,0 +1,5 @@
+[project]
+name = "myproject"
+version = "0.1.0"
+
+[dependencies]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,68 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    /// Optional name to operate on
+    name: Option<String>,
+
+    /// Sets a custom config file
+    #[arg(short, long, value_name = "FILE")]
+    config: Option<PathBuf>,
+
+    /// Turn debugging information on
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    debug: u8,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// does testing things
+    Test {
+        /// lists test values
+        #[arg(short, long)]
+        list: bool,
+    },
+}
+
 fn main() {
-    println!("Hello, world!");
+    let cli = Cli::parse();
+
+    // You can check the value provided by positional arguments, or option arguments
+    if let Some(name) = cli.name.as_deref() {
+        println!("Value for name: {name}");
+    }
+
+    if let Some(config_path) = cli.config.as_deref() {
+        println!("Value for config: {}", config_path.display());
+    }
+
+    // You can see how many times a particular flag or argument occurred
+    // Note, only flags can have multiple occurrences
+    match cli.debug {
+        0 => println!("Debug mode is off"),
+        1 => println!("Debug mode is kind of on"),
+        2 => println!("Debug mode is on"),
+        _ => println!("Don't be crazy"),
+    }
+
+    // You can check for the existence of subcommands, and if found use their
+    // matches just as you would the top level cmd
+    match &cli.command {
+        Some(Commands::Test { list }) => {
+            if *list {
+                println!("Printing testing lists...");
+            } else {
+                println!("Not printing testing lists...");
+            }
+        }
+        None => {}
+    }
+
+    // Continued program logic goes here...
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,10 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
+use serde::Serialize;
+// use std::fs::File;
+// use std::io::Write;
+
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
@@ -62,7 +66,7 @@ fn main() {
     match &cli.command {
         Some(Commands::Init { path }) => {
             if *path {
-                println!("initializing...");
+                let _ = init();
             } else {
                 println!("Not initializing...");
             }
@@ -85,4 +89,46 @@ fn main() {
     }
 
     // Continued program logic goes here...
+    #[derive(Serialize)]
+    struct Project {
+        name: String,
+        version: String,
+    }
+
+    #[derive(Serialize)]
+    struct Manifest {
+        project: Project,
+        dependencies: std::collections::HashMap<String, String>,
+    }
+
+    // #[derive(Serialize)]
+    // struct Config {
+    //     name: String,
+    //     version: String,
+    //     authors: Vec<String>,
+    //     debug: bool,
+    // }
+
+    fn init() -> Result<(), Box<dyn std::error::Error>> {
+        println!("initializing...");
+
+        let project = Project {
+            name: "myproject".into(),
+            version: "0.1.0".into(),
+        };
+
+        let manifest = Manifest {
+            project,
+            dependencies: std::collections::HashMap::new(),
+        };
+
+        // Serialize to a TOML string
+        let toml_string = toml::to_string_pretty(&manifest)?;
+
+        // Write to a file
+        std::fs::write("mypkg.toml", toml_string)?;
+
+        println!("mypkg.toml written successfully.");
+        Ok(())
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -126,9 +126,13 @@ fn main() {
         let toml_string = toml::to_string_pretty(&manifest)?;
 
         // Write to a file
-        std::fs::write("mypkg.toml", toml_string)?;
+        std::fs::write("./temp/mypkg.toml", toml_string)?;
 
         println!("mypkg.toml written successfully.");
+
+        std::fs::create_dir("./temp/.box")?;
+        std::fs::create_dir_all("./temp/.box/cache")?;
+
         Ok(())
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,8 @@ use serde::Serialize;
 // use std::fs::File;
 // use std::io::Write;
 
+use box_core::test;
+
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
@@ -60,6 +62,8 @@ fn main() {
         project,
         dependencies: std::collections::HashMap::new(),
     };
+
+    test();
 
     // You can see how many times a particular flag or argument occurred
     // Note, only flags can have multiple occurrences

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,11 +22,17 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// does testing things
-    Test {
-        /// lists test values
+    Init {
         #[arg(short, long)]
-        list: bool,
+        path: bool,
+    },
+    Add {
+        #[arg(short, long)]
+        path: bool,
+    },
+    Install {
+        #[arg(short, long)]
+        path: bool,
     },
 }
 
@@ -44,21 +50,35 @@ fn main() {
 
     // You can see how many times a particular flag or argument occurred
     // Note, only flags can have multiple occurrences
-    match cli.debug {
-        0 => println!("Debug mode is off"),
-        1 => println!("Debug mode is kind of on"),
-        2 => println!("Debug mode is on"),
-        _ => println!("Don't be crazy"),
-    }
+    // match cli.debug {
+    //     0 => println!("Debug mode is off"),
+    //     1 => println!("Debug mode is kind of on"),
+    //     2 => println!("Debug mode is on"),
+    //     _ => println!("Don't be crazy"),
+    // }
 
     // You can check for the existence of subcommands, and if found use their
     // matches just as you would the top level cmd
     match &cli.command {
-        Some(Commands::Test { list }) => {
-            if *list {
-                println!("Printing testing lists...");
+        Some(Commands::Init { path }) => {
+            if *path {
+                println!("initializing...");
             } else {
-                println!("Not printing testing lists...");
+                println!("Not initializing...");
+            }
+        }
+        Some(Commands::Add { path }) => {
+            if *path {
+                println!("Adding...");
+            } else {
+                println!("Not adding...");
+            }
+        }
+        Some(Commands::Install { path }) => {
+            if *path {
+                println!("installing...");
+            } else {
+                println!("Not installing...");
             }
         }
         None => {}

--- a/manifest/src/main.rs
+++ b/manifest/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
- added clap for cli
- cli creates basic toml file and writes to file
- cli creates a project .box and cache folder in it
- add writes dependency to toml file
- added system resolve functions to query platform info
- created BuildTuple to manage dependency and build information
- using get_build_tuple and get_system_info for core in CLI to write hash folder name in cache